### PR TITLE
fix CJK encoding before extract for ZipArchive

### DIFF
--- a/src/Extractor/Adapter/ZipExtractorAdapter.php
+++ b/src/Extractor/Adapter/ZipExtractorAdapter.php
@@ -55,8 +55,18 @@ class ZipExtractorAdapter extends AbstractExtractorAdapter implements ExtractorA
         $directory = $this->directory->getDirectoryPath();
         $zipArchive = new ZipArchive();
         $zipArchive->open($filePath);
-        $zipArchive->extractTo($directory);
 
+        //fix CJK encoding before extract
+        $encodes = ['UTF-8','GB18030','GBK','GB2312','BIG5','CP936','CP932'];
+        for ($i = 0; $i < $zipArchive->numFiles; $i++) {
+            $name = $zipArchive->statIndex($i, \ZipArchive::FL_ENC_RAW)['name'];
+            $encoding = mb_detect_encoding($name, $encodes);
+            if($encoding != 'UTF-8'){
+                $zipArchive->renameIndex($i, iconv($encoding,'utf-8//IGNORE', $name));
+            }
+        }
+
+        $zipArchive->extractTo($directory);
         return $this->createFinderFromDirectory($directory);
     }
 }


### PR DESCRIPTION
Hi, as you may know, some windows zip tools use the OS local codepage to encode the file/path names, it always makes ZipArchive can't work properly when the zip file contains NON-ASCII names. We fix it by add a preprocess to handle with the zip index names.